### PR TITLE
fix: add a WORKSPACE file

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,2 @@
+# This file must be present for Bazel 6.
+# TODO(1.0) delete


### PR DESCRIPTION
Should green up the BCR testing for Bazel 6, which we still want since bazel-lib supports it until LTS ends