### PR TITLE
chore: add missing matrix to AW

### DIFF
--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -1,5 +1,23 @@
 # See https://docs.aspect.build/workflows/configuration
+workspaces:
+  - .
+  - docs
+  - e2e/smoke
 tasks:
   - test:
+      name: "Test (Bazel 6.x)"
+      id: bazel-6
+      env:
+        USE_BAZEL_VERSION: 6.x
+  - test:
+      name: "Test (Bazel 7.x)"
+      id: bazel-7
+      env:
+        USE_BAZEL_VERSION: 7.x
+  - test:
+      name: "Test (Bazel 8.x)"
+      id: bazel-8
+      env:
+        USE_BAZEL_VERSION: 8.x
 notifications:
   github: {}

--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -1,7 +1,12 @@
 # See https://docs.aspect.build/workflows/configuration
 workspaces:
   - .
-  - docs
+  - docs:
+      tasks:
+        - bazel-7:
+            without: true
+        - bazel-6:
+            without: true
   - e2e/smoke
 tasks:
   - test:

--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -8,7 +8,10 @@ workspaces:
         - bazel-6:
             without: true
   - e2e/smoke
-  - examples
+  - examples:
+      tasks:
+        - bazel-6:
+            without: true
 tasks:
   - test:
       name: "Test (Bazel 6.x)"

--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -12,6 +12,10 @@ tasks:
   - test:
       name: "Test (Bazel 6.x)"
       id: bazel-6
+      bazel:
+        flags:
+          - --enable_bzlmod
+          - --test_tag_filters=-broken-on-bazel6
       env:
         USE_BAZEL_VERSION: 6.x
   - test:

--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -8,6 +8,7 @@ workspaces:
         - bazel-6:
             without: true
   - e2e/smoke
+  - examples
 tasks:
   - test:
       name: "Test (Bazel 6.x)"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,11 @@ jobs:
     strategy:
       matrix:
         # Note: linux is tested on Buildkite via Aspect Workflows
-        os: [windows-latest, macos-latest]
+        os:
+          - macos-latest
+          # TODO: Windows was disabled in the original bazel-lib location where tar was tested:
+          # https://github.com/bazel-contrib/bazel-lib/blob/8a9204ab17cbe337a64e838dd193b00f243764fb/.github/workflows/ci.yaml#L92
+          # - windows-latest
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,31 +15,15 @@ concurrency:
   cancel-in-progress: ${{ github.ref_name != 'main' }}
 jobs:
   test:
-    uses: bazel-contrib/.github/.github/workflows/bazel.yaml@v7.2.2
-    with:
-      # TODO: this was disabled in the old location where tar was tested:
-      # https://github.com/bazel-contrib/bazel-lib/blob/8a9204ab17cbe337a64e838dd193b00f243764fb/.github/workflows/ci.yaml#L92
-      exclude_windows: true
-      folders: |
-        [
-          ".",
-          "docs",
-          "e2e/smoke",
-          "examples"
-        ]
-      exclude: |
-        [
-          {"folder": ".", "os": "ubuntu-latest", "bazelversion": "7.6.1"},
-          {"folder": ".", "bzlmodEnabled": false},
-          {"folder": "docs", "bzlmodEnabled": false},
-          {"folder": "docs", "bazelversion": "7.6.1"},
-          {"folder": "docs", "os": "macos-latest"},
-          {"folder": "docs", "os": "windows-latest"},
-          {"folder": "examples", "os": "macos-latest"},
-          {"folder": "examples", "os": "windows-latest"},
-          {"folder": "examples", "bazelversion": "7.6.1"},
-          {"folder": "examples", "bzlmodEnabled": false}
-        ]
+    strategy:
+      matrix:
+        # Note: linux is tested on Buildkite via Aspect Workflows
+        os: [windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bazel-contrib/setup-bazel@0.15.0
+      - run: bazel test //...
   pre-commit:
     runs-on: ubuntu-latest
     steps:

--- a/tar/tests/BUILD
+++ b/tar/tests/BUILD
@@ -197,6 +197,7 @@ diff_test(
     timeout = "short",
     file1 = "src_file",
     file2 = "cat_src_file_output",
+    tags = ["broken-on-bazel6"],
 )
 
 #############
@@ -563,6 +564,7 @@ assert_tar_listing(
         "-rwxr-xr-x  0 0      0           0 Jan  1  2023 tar/tests/native_binary_bin.runfiles/_main/tar/tests/native_binary_bin",
         "-rwxr-xr-x  0 0      0           0 Jan  1  2023 tar/tests/native_binary_bin.runfiles/_repo_mapping",
     ],
+    tags = ["broken-on-bazel6"],
 )
 
 mtree_mutate(
@@ -604,4 +606,5 @@ assert_tar_listing(
         "lrwxr-xr-x  0 0      0           0 Jan  1  2023 tar/tests/native_binary_bin.runfiles/_main/tar/tests/native_binary_bin -> ../executable.sh",
         "-rwxr-xr-x  0 0      0           0 Jan  1  2023 tar/tests/native_binary_bin.runfiles/_repo_mapping",
     ],
+    tags = ["broken-on-bazel6"],
 )

--- a/tar/tests/asserts.bzl
+++ b/tar/tests/asserts.bzl
@@ -4,7 +4,7 @@ load("@aspect_bazel_lib//lib:diff_test.bzl", "diff_test")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 
 # buildifier: disable=function-docstring
-def assert_tar_listing(name, actual, expected):
+def assert_tar_listing(name, actual, expected, tags = []):
     actual_listing = "{}_listing".format(name)
     expected_listing = "{}_expected".format(name)
 
@@ -30,6 +30,7 @@ def assert_tar_listing(name, actual, expected):
         file1 = actual_listing,
         file2 = expected_listing,
         timeout = "short",
+        tags = tags,
     )
 
 # buildifier: disable=function-docstring


### PR DESCRIPTION
Moves all Linux testing to Aspect Workflows on Buildkite.

Macos testing remains on Github Actions, only bothering to test the root repository. BCR Presubmit will add more OS coverage to the e2e/smoke.

Windows testing remains off, I checked that it's still broken, can address that in a follow-up.