### PR TITLE
chore: test on Bazel 9, stop testing on Bazel 6

### DIFF
--- a/.aspect/workflows/config.yaml
+++ b/.aspect/workflows/config.yaml
@@ -5,23 +5,11 @@ workspaces:
       tasks:
         - bazel-7:
             without: true
-        - bazel-6:
+        - bazel-9:
             without: true
   - e2e/smoke
-  - examples:
-      tasks:
-        - bazel-6:
-            without: true
+  - examples
 tasks:
-  - test:
-      name: "Test (Bazel 6.x)"
-      id: bazel-6
-      bazel:
-        flags:
-          - --enable_bzlmod
-          - --test_tag_filters=-broken-on-bazel6
-      env:
-        USE_BAZEL_VERSION: 6.x
   - test:
       name: "Test (Bazel 7.x)"
       id: bazel-7
@@ -32,5 +20,10 @@ tasks:
       id: bazel-8
       env:
         USE_BAZEL_VERSION: 8.x
+  - test:
+      name: Test (Bazel 9.x)
+      id: bazel-9
+      env:
+        USE_BAZEL_VERSION: rolling
 notifications:
   github: {}

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,7 +6,7 @@ module(
     compatibility_level = 1,
 )
 
-bazel_dep(name = "aspect_bazel_lib", version = "2.14.0")
+bazel_dep(name = "aspect_bazel_lib", version = "2.19.2")
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
 bazel_dep(name = "platforms", version = "0.0.11")
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,2 +1,0 @@
-# This file must be present for Bazel 6.
-# TODO(1.0) delete

--- a/tar/tests/BUILD
+++ b/tar/tests/BUILD
@@ -164,7 +164,7 @@ sh_binary(
     name = "cat_src_file",
     srcs = ["cat_src_file.sh"],
     data = ["src_file"],
-    deps = ["@bazel_tools//tools/bash/runfiles"],
+    deps = ["@rules_shell//shell/runfiles"],
 )
 
 tar(

--- a/tar/tests/BUILD
+++ b/tar/tests/BUILD
@@ -199,7 +199,6 @@ diff_test(
     timeout = "short",
     file1 = "src_file",
     file2 = "cat_src_file_output",
-    tags = ["broken-on-bazel6"],
 )
 
 #############
@@ -566,7 +565,6 @@ assert_tar_listing(
         "-rwxr-xr-x  0 0      0           0 Jan  1  2023 tar/tests/native_binary_bin.runfiles/_main/tar/tests/native_binary_bin",
         "-rwxr-xr-x  0 0      0           0 Jan  1  2023 tar/tests/native_binary_bin.runfiles/_repo_mapping",
     ],
-    tags = ["broken-on-bazel6"],
 )
 
 mtree_mutate(
@@ -608,7 +606,6 @@ assert_tar_listing(
         "lrwxr-xr-x  0 0      0           0 Jan  1  2023 tar/tests/native_binary_bin.runfiles/_main/tar/tests/native_binary_bin -> ../executable.sh",
         "-rwxr-xr-x  0 0      0           0 Jan  1  2023 tar/tests/native_binary_bin.runfiles/_repo_mapping",
     ],
-    tags = ["broken-on-bazel6"],
 )
 
 #############

--- a/tar/tests/cat_src_file.sh
+++ b/tar/tests/cat_src_file.sh
@@ -5,7 +5,7 @@
 # Copy-pasted from the Bazel Bash runfiles library v3.
 set -uo pipefail
 set +e
-f=bazel_tools/tools/bash/runfiles/runfiles.bash
+f=rules_shell/shell/runfiles/runfiles.bash
 source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
   source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
   source "$0.runfiles/$f" 2>/dev/null ||

--- a/tar/tests/cat_src_file.sh
+++ b/tar/tests/cat_src_file.sh
@@ -5,7 +5,7 @@
 # Copy-pasted from the Bazel Bash runfiles library v3.
 set -uo pipefail
 set +e
-f=rules_shell/shell/runfiles/runfiles.bash
+f=bazel_tools/tools/bash/runfiles/runfiles.bash
 source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null ||
   source "$(grep -sm1 "^$f " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null ||
   source "$0.runfiles/$f" 2>/dev/null ||


### PR DESCRIPTION
Preparing for 1.0 here, where we should disclaim support for older Bazel that has bzlmod bugs.

This will let us rely on the MODULE.bazel.lock file to pin the version of libarchive / bsdtar_prebuilt when moving that toolchain here.