### PR TITLE
assert_tars_match: support pre-sorting the listings

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,6 +5,7 @@ module(
     compatibility_level = 1,
 )
 
+bazel_dep(name = "bazel_features", version = "1.34.0")
 bazel_dep(name = "aspect_bazel_lib", version = "2.19.3")
 bazel_dep(name = "bazel_skylib", version = "1.4.1")
 bazel_dep(name = "gawk", version = "5.3.2.bcr.1")


### PR DESCRIPTION
The order of a listing _does_ actually matter in terms of what actually ends up in the tar, but it's helpful for test purposes to be able to ignore the order when comparing tars created via different mechanisms.