### PR TITLE
chore: make sure an untidy lockfile doesn't pass CI

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -4,3 +4,6 @@ common --config=ruleset
 
 # also see: https://blog.aspect.build/configuring-bazels-downloader
 common --experimental_downloader_config=tools/downloader.cfg
+
+# CI should never be updating the lockfile (if so, that means someone forgot to check it in)
+common:ci --lockfile_mode=error


### PR DESCRIPTION
This PR will fail until https://github.com/bazel-contrib/tar.bzl/pull/55 lands (which fixes the untidy lockfile)