### PR TITLE
fix: use hardcode in create_repositories function

### DIFF
--- a/tar/extensions.bzl
+++ b/tar/extensions.bzl
@@ -6,7 +6,7 @@ load("//tar/toolchain:toolchain.bzl", "tar_toolchains_repo")
 def create_repositories(name = "bsd_tar_toolchains"):
     tar_toolchains_repo(name = name, user_repository_name = name)
     for platform in BSDTAR_PLATFORMS.keys():
-        bsdtar_binary_repo(name = "{}_{}".format("bsd_tar_toolchains", platform), platform = platform)
+        bsdtar_binary_repo(name = "{}_{}".format(name, platform), platform = platform)
 
 def _toolchains_extension(mctx):
     create_repositories()


### PR DESCRIPTION
This PR fixes https://github.com/bazel-contrib/tar.bzl/issues/66 by replacing harcoded string with proper parameter name
