### PR TITLE
docs: correct README instructions on no-remote-cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Use a snippet like the following in `.bazelrc`:
 ```
 # Avoid overloading the remote cache with tar outputs.
 # See https://github.com/bazel-contrib/tar.bzl/blob/main/README.md#remote-cache-and-rbe
-common --execution_requirements=Tar=+no-remote-cache
+common --modify_execution_info=Tar=+no-remote-cache
 ```
 
 ## Examples


### PR DESCRIPTION
The bazel cli flag for the section on improving remote caching is using the name `execution_requirements` from the parameters of `actions`, while the actual name for the CLI argument is (unfortunately) `modify_execution_info`.

Fixes #79