### PR TITLE
feat: Allow no compression as accepted compress argument

### DIFF
--- a/tar/private/tar.bzl
+++ b/tar/private/tar.bzl
@@ -38,8 +38,10 @@ _COMPRESSION_TO_EXTENSION = {
     "zstd": ".tar.zst",
 }
 
+_NO_COMPRESSION = ""
+
 # https://www.gnu.org/software/tar/manual/html_section/Compression.html
-_ACCEPTED_COMPRESSION_TYPES = _COMPRESSION_TO_EXTENSION.keys()
+_ACCEPTED_COMPRESSION_TYPES = _COMPRESSION_TO_EXTENSION.keys() + [_NO_COMPRESSION]
 
 _tar_attrs = {
     "args": attr.string_list(


### PR DESCRIPTION
https://github.com/aspect-build/rules_py/blob/f0667bd424ecbc1ef78b38a929d37d6aa21e636e/py/private/py_image_layer.bzl#L107 is setting a compression by default. With that it is not possible to unset the compression anymore as `""` is not an accepted compression type. I think no compression should be an accepted type.