### PR TITLE
fix: add root bzl_library

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,3 +1,4 @@
+load("@bazel_lib//:bzl_library.bzl", "bzl_library")
 load("@bazel_lib//lib:diff_test.bzl", "diff_test")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("//tar:mtree.bzl", "mtree_spec")
@@ -37,4 +38,14 @@ diff_test(
     name = "tar_test13",
     file1 = "tar_test13_mtree",
     file2 = "//tar/tests:expected13.mtree",
+)
+
+bzl_library(
+    name = "tar",
+    srcs = ["tar.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//tar",
+        "//tar:mtree",
+    ],
 )


### PR DESCRIPTION
Needed if you import the root tar.bzl file
