### PR TITLE
fix(preserve_symlinks): detect symlinks under any transitioned config

### DIFF
--- a/tar/private/preserve_symlinks.awk
+++ b/tar/private/preserve_symlinks.awk
@@ -69,22 +69,60 @@ function make_relative_link(path1, path2, i, common, target, relative_path, back
             path = parts[2]
             # Store paths for look up
             symlink_map[path] = $1
-            # Resolve the symlink if it exists
-            resolved_path = ""
-            cmd = "readlink -f \"" path "\""
-            cmd | getline resolved_path
+            # Resolve the symlink if it exists.
+            #
+            # We call plain `readlink` first and keep its result only if it
+            # returned a RELATIVE string. That's specifically for
+            # `declare_symlink` outputs whose `target_path` is an authored
+            # relative string (e.g. `../foo/bar` or `sibling-name`) that we
+            # want to preserve verbatim in the archive — `readlink -f`
+            # would canonicalise these through and lose the intent.
+            #
+            # For anything else (plain returns absolute, or nothing),
+            # `readlink -f` walks the full chain. That handles:
+            #   * absolute Bazel-produced symlinks (`ctx.actions.symlink`
+            #     with `target_file`).
+            #   * sandboxed-action execution, where plain `readlink` on a
+            #     relative input path returns the sandbox→main-execroot
+            #     mapping (`/.../execroot/_main/<path>`) — uninformative
+            #     for classification; canonical resolution is what we want.
+            raw_readlink = ""
+            cmd = "readlink \"" path "\""
+            cmd | getline raw_readlink
             close(cmd)
-            # If readlink -f fails use readlink for relative links
-            if (resolved_path == "") {
-                cmd = "readlink \"" path "\""
+            resolved_path = ""
+            if (raw_readlink != "" && raw_readlink !~ /^\//) {
+                resolved_path = raw_readlink
+            } else {
+                cmd = "readlink -f \"" path "\""
                 cmd | getline resolved_path
                 close(cmd)
             }
 
             if (resolved_path) {
-                if (resolved_path ~ bin_dir || resolved_path ~ /\.\.\//) {
-                    # Strip down the resolved path to start from bin_dir
-                    sub("^.*" bin_dir, bin_dir, resolved_path)
+                # Accept any of:
+                #  * absolute paths under `/.../bazel-out/<any-cfg>/bin/...`
+                #    (declare_file / declare_directory outputs). We don't
+                #    require <cfg> to equal the mtree_mutate action's own
+                #    `ctx.bin_dir.path` — downstream targets frequently sit
+                #    under transitioned configs (`-ST-<hash>` / `-opt-exec-ST-<hash>`
+                #    / platform_transition variants), and we want their
+                #    symlinks classified too.
+                #  * absolute paths under `/.../external/<repo>/...`, which
+                #    is where Bazel puts files for external repos that don't
+                #    go through `bazel-out` (e.g. python-build-standalone's
+                #    interpreter tree in rules_python).
+                #  * relative paths (e.g. `../foo`) — declare_symlink outputs
+                #    whose target_path was authored as a relative string.
+                #
+                # In each case, normalise `resolved_path` to the execroot-
+                # relative form that the mtree's `content=` fields use so
+                # `symlink_map` lookups can match.
+                if (resolved_path ~ /\/bazel-out\/[^\/]+\/bin\// || \
+                    resolved_path ~ /\/external\// || \
+                    resolved_path ~ /\.\.\//) {
+                    sub(/^.*\/bazel-out\//, "bazel-out/", resolved_path)
+                    sub(/^.*\/external\//, "external/", resolved_path)
                     # If the resolved path is different from the original path,
                     # or if it's a relative path
                     if (path != resolved_path || resolved_path ~ /\.\.\//) {


### PR DESCRIPTION
## Summary

The `preserve_symlinks` awk classifies a `type=file content=<path>` row as a symlink when `readlink` on the content path returns a target that lives "inside the bazel tree". Today that check is:

```awk
cmd = "readlink -f \"" path "\""
cmd | getline resolved_path
close(cmd)
# fallback to plain readlink if -f returned empty
...

if (resolved_path) {
    if (resolved_path ~ bin_dir || resolved_path ~ /\.\.\//) {
        sub("^.*" bin_dir, bin_dir, resolved_path)
        ...
```

`bin_dir` is the `ctx.bin_dir.path` of the `mtree_mutate` action itself — e.g. `bazel-out/k8-fastbuild/bin`. Any symlink whose target lives under a *transitioned* config (`bazel-out/k8-fastbuild-ST-<hash>/bin/...`, `bazel-out/k8-opt-exec-ST-<hash>/bin/...`, `platform_transition_*` variants) fails the regex check and is left classified as `type=file`. bsdtar then follows it during archiving and inlines the real bytes.

Impact:

1. **Tar size.** A binary's runfiles that contain tree-artifact symlink aliases to other archive members (rules_py's per-top-level venv layout is the obvious case; pnpm `node_modules` crossing a transition is another) end up storing the same bytes twice.

2. **Correctness.** Symlinks to external-repo files are missed entirely. rules_python's standalone interpreter lives at `external/<repo>/bin/python3` — directly under `external/`, not `bazel-out/<cfg>/bin/`. The awk's only absolute-path check was `resolved_path ~ bin_dir`, so such paths fell through as `type=file`. In a container the inlined Python binary loses its relationship to its install tree, `sys.base_prefix` resolves to the compile-time default (`/install` for python-build-standalone), and Python dies at `ModuleNotFoundError: No module named 'encodings'`.

## Changes

Three small changes in the same detection block:

1. **Accept `bazel-out/<any-cfg>/bin/`** instead of only the action's own `bin_dir`. Downstream targets frequently sit under transitioned configs; their symlinks should classify too.

2. **Accept `external/<repo>/`** paths for files that live directly under `external/` (PBS-style interpreter trees).

3. **Flip the readlink order.** Try plain `readlink` first; keep its result only if it's relative — that's exactly the authored `target_path` of a `declare_symlink` output, which we want to preserve verbatim in the archive rather than canonicalise away. Fall back to `readlink -f` for absolute or empty results (the latter happens in sandboxed actions where plain `readlink` on a relative input returns an uninformative sandbox→main-execroot mapping).

`bin_dir` is still accepted as an awk variable (mtree_mutate continues to pass it) — just no longer consulted, so existing callers and custom awk scripts keep working.

## Test plan

- [x] `bazel test //tar/tests/...` — all 24 tests pass unchanged. `test_17_after_processing`'s `node_modules/.pnpm/b@0.0.0/...` symlinks exercise the primary code path and still produce the expected listing.
- [x] Downstream validation: rules_py's `py_image_layer` now:
  - Correctly writes `type=link` for venv-to-interpreter symlinks crossing a `python_version_transition` boundary (previously inlined as bytes, breaking Python's base_prefix discovery in OCI containers).
  - Stops duplicating wheel content in the packages layer for transitioned venv alias paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)