### PR TITLE
fix: preserve owner/group on package_dir-synthesized parent directories

### DIFF
--- a/tar/private/default.awk
+++ b/tar/private/default.awk
@@ -55,6 +55,16 @@
     }
 
     if (package_dir != "") {
+        # Compose ownership keywords that should also apply to synthesized parent
+        # directories, so they don't override pre-existing ownership when this tar
+        # is flattened/extracted alongside layers that already declare those dirs.
+        # See https://github.com/bazel-contrib/tar.bzl/issues/91.
+        ownership_attrs = ""
+        if (owner != "")     ownership_attrs = ownership_attrs " uid=" owner
+        if (group != "")     ownership_attrs = ownership_attrs " gid=" group
+        if (ownername != "") ownership_attrs = ownership_attrs " uname=" ownername
+        if (groupname != "") ownership_attrs = ownership_attrs " gname=" groupname
+
         # First ensure parent directories exist
         if (!($0 ~ /type=dir/)) {
             split(package_dir, dirs, "/")
@@ -67,7 +77,7 @@
                 }
                 # Only print if we haven't seen this directory before
                 if (!(path in seen_dirs)) {
-                    print path " type=dir mode=0755 time=" default_time
+                    print path " type=dir mode=0755 time=" default_time ownership_attrs
                     seen_dirs[path] = 1
                 }
             }

--- a/tar/tests/BUILD
+++ b/tar/tests/BUILD
@@ -827,3 +827,41 @@ assert_tar_listing(
         "-rw-r--r--  0 0      0          21 Jan  1  2023 src_file",
     ],
 )
+
+#############
+# Example 22: package_dir-synthesized parent directories carry the configured
+# owner/group/ownername/groupname instead of defaulting to root:root.
+# Regression test for https://github.com/bazel-contrib/tar.bzl/issues/91.
+mtree_spec(
+    name = "mtree22",
+    srcs = ["src_file"],
+)
+
+mtree_mutate(
+    name = "mutate22",
+    group = "1000",
+    groupname = "nonroot",
+    mtree = ":mtree22",
+    owner = "1000",
+    ownername = "nonroot",
+    package_dir = "home/nonroot/dir",
+    strip_prefix = "tar/tests",
+)
+
+tar(
+    name = "tar22",
+    srcs = ["src_file"],
+    out = "22.tar",
+    mtree = ":mutate22",
+)
+
+assert_tar_listing(
+    name = "test22_package_dir_ownership",
+    actual = ":tar22",
+    expected = [
+        "drwxr-xr-x  0 nonroot nonroot     0 Jan  1  2000 home/",
+        "drwxr-xr-x  0 nonroot nonroot     0 Jan  1  2000 home/nonroot/",
+        "drwxr-xr-x  0 nonroot nonroot     0 Jan  1  2000 home/nonroot/dir/",
+        "-rwxr-xr-x  0 1000    1000       21 Jan  1  2023 home/nonroot/dir/src_file",
+    ],
+)


### PR DESCRIPTION
When package_dir auto-generates parent directories (like home/ubuntu/), it previously left out ownership fields, causing them to default to root:root. When extracted alongside other layers, these root-owned entries overwrite the correct permissions and break access for non-root users.

This PR fixes this by passing the configured owner, group, ownername, and groupname down to those synthesized directories so they no longer clobber existing ownership.

Includes a regression test (Example 22) to verify that generated parent directories correctly inherit the specified uname and gname.

Fixes #91.