### PR TITLE
fix: upgrade bsdtar-prebuilt to `v3.8.1-3`

### DIFF
--- a/tar/toolchain/versions.bzl
+++ b/tar/toolchain/versions.bzl
@@ -6,27 +6,27 @@ Of course they are free to just register a different toolchain themselves.
 
 BSDTAR_PREBUILT = {
     "darwin_amd64": (
-        "https://github.com/aspect-build/bsdtar-prebuilt/releases/download/v3.8.1-fix.1/tar_darwin_amd64",
-        "e8893f7d775d070a333dc386b2aab70dfa43411fcd890222c81212724be7de25",
+        "https://github.com/hermeticbuild/bsdtar-prebuilt/releases/download/v3.8.1-3/tar_darwin_amd64",
+        "088ca0f5a655c47fdb3706a599fbd45ab49636bf05eaab3af7df0cafe166168d",
     ),
     "darwin_arm64": (
-        "https://github.com/aspect-build/bsdtar-prebuilt/releases/download/v3.8.1-fix.1/tar_darwin_arm64",
-        "48c1bd214aac26487eaf623d17b77ebce4db3249be851a54edcc940d09d50999",
+        "https://github.com/hermeticbuild/bsdtar-prebuilt/releases/download/v3.8.1-3/tar_darwin_arm64",
+        "f78ae63e48f58be8e88bb1e44ab165503b8bdc7374cebdeb7fa9327629c88907",
     ),
     "linux_amd64": (
-        "https://github.com/aspect-build/bsdtar-prebuilt/releases/download/v3.8.1-fix.1/tar_linux_amd64",
-        "fff8f72758a52e60fe82beae64b18e7996467013ffe8bec09173d1ba6b66e490",
+        "https://github.com/hermeticbuild/bsdtar-prebuilt/releases/download/v3.8.1-3/tar_linux_amd64",
+        "ae24dbc3ecf6ad628c2fdd205a52347fd4446589e750469766669e25cb80e22b",
     ),
     "linux_arm64": (
-        "https://github.com/aspect-build/bsdtar-prebuilt/releases/download/v3.8.1-fix.1/tar_linux_arm64",
-        "683468ae45d371e4f392b0e5a524440f6f4507d7da0db60d03ff31f3cf951fc3",
+        "https://github.com/hermeticbuild/bsdtar-prebuilt/releases/download/v3.8.1-3/tar_linux_arm64",
+        "673897c180d9c27770fad1e55914653a6da85fc1f6500df3d768c32916ab8747",
     ),
     "windows_arm64": (
-        "https://github.com/aspect-build/bsdtar-prebuilt/releases/download/v3.8.1-fix.1/tar_windows_arm64.exe",
-        "130d69268b0a387bca387d00663821779dd1915557caf7fcbfd5ded3f41074f3",
+        "https://github.com/hermeticbuild/bsdtar-prebuilt/releases/download/v3.8.1-3/tar_windows_arm64.exe",
+        "8a8b94df9bca7ce3f1b47a5bdb507627e4a0dcb8e9d429a37fe37e5aa729208b",
     ),
     "windows_amd64": (
-        "https://github.com/aspect-build/bsdtar-prebuilt/releases/download/v3.8.1-fix.1/tar_windows_x86_64.exe",
-        "f48c81e1812956adb4906c6f057ca856dd280a455e7867d77800e6d5ef9fc81d",
+        "https://github.com/hermeticbuild/bsdtar-prebuilt/releases/download/v3.8.1-3/tar_windows_x86_64.exe",
+        "550fc86489a24c0774d3cafbe326c1da01f374521154e9f0b9b77332b48e8b46",
     ),
 }


### PR DESCRIPTION
Statically linked on Windows to avoid `vcruntime140.dll` dynamic linking.