### PR TITLE
chore: upgrade release_ruleset workflow to 7.4.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ permissions:
   contents: write
 jobs:
   release:
-    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.2.2
+    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.4.0
     with:
       release_files: tar.bzl-*.tar.gz
       prerelease: false


### PR DESCRIPTION
To try to fix the BCR release process: https://github.com/bazel-contrib/tar.bzl/actions/runs/25387734065/job/74468955086