### PR TITLE
feat: add excludes support to mtree_mutate and tar rules

### DIFF
--- a/tar/mtree.bzl
+++ b/tar/mtree.bzl
@@ -50,6 +50,7 @@ def mtree_mutate(
         mtime = None,
         owner = None,
         ownername = None,
+        excludes = None,
         awk_script = Label("@tar.bzl//tar/private:default.awk"),
         script_args = {},
         includes = None,
@@ -66,6 +67,7 @@ def mtree_mutate(
         mtime: new modification time for all entries.
         owner: new uid for all entries.
         ownername: new uname for all entries.
+        excludes: list of paths to exclude from the tar. Paths are matched exactly against the original paths before any strip_prefix or package_dir transformations are applied.
         awk_script: awk script for mtree mutation. Override to provide a custom script; use @include "default" to compose with the built-in pipeline.
         script_args: extra key=value variables passed via --assign. Available in awk_script and any includes.
         includes: additional awk scripts appended after awk_script. A wrapper is generated that @include-s awk_script then each script here in order.
@@ -87,6 +89,7 @@ def mtree_mutate(
         mtime = str(mtime) if mtime else None,
         owner = owner,
         ownername = ownername,
+        excludes = excludes,
         awk_script = awk_script,
         script_args = script_args,
         includes = includes or [],

--- a/tar/private/default.awk
+++ b/tar/private/default.awk
@@ -1,6 +1,21 @@
 # Default mtree mutation pipeline. Reusable via: @include "default"
 
+BEGIN {
+    # Pre-process excludes into an associative array for O(1) lookup
+    if (excludes != "") {
+        split(excludes, exclude_list, "\036")
+        for (i in exclude_list) {
+            exclude_map[exclude_list[i]] = 1
+        }
+    }
+}
+
 {
+    # Handle excludes - check if the current path should be excluded
+    if ($1 in exclude_map) {
+        next
+    }
+
     if (strip_prefix != "") {
         if ($1 == strip_prefix) {
             # this line declares the directory which is now the root. It may be discarded.

--- a/tar/private/tar.bzl
+++ b/tar/private/tar.bzl
@@ -208,6 +208,9 @@ _mutate_mtree_attrs = {
     "groupname": attr.string(
         doc = "Specifies the name of the group of the files in the tar archive. Used alongside 'group'.",
     ),
+    "excludes": attr.string_list(
+        doc = "List of paths to exclude from the tar archive. Paths are matched exactly against the original paths before any strip_prefix or package_dir transformations are applied.",
+    ),
     "out": attr.output(
         doc = "The output of the mutation, a new mtree file.",
     ),
@@ -624,6 +627,10 @@ def _mtree_mutate_impl(ctx):
         assignments["mtime"] = ctx.attr.mtime
     if ctx.attr.preserve_symlinks:
         assignments["preserve_symlinks"] = 1
+    if ctx.attr.excludes:
+        # Pass excludes as a delimited string for AWK to parse
+        # Use ASCII 0x1E (record separator) as delimiter to avoid conflicts with paths
+        assignments["excludes"] = "\036".join(ctx.attr.excludes)
     for (key, value) in assignments.items():
         args.add_joined(["--assign", key, value], join_with = "=")
 

--- a/tar/tar.bzl
+++ b/tar/tar.bzl
@@ -56,6 +56,23 @@ tar(
     ...
 )
 ```
+
+Exclude specific files from the archive, such as duplicate binaries in runfiles:
+
+```starlark
+load("@tar.bzl", "mutate", "tar")
+
+tar(
+    name = "my_app_tar",
+    srcs = [":my_binary"],
+    include_runfiles = True,
+    mutate = mutate(
+        excludes = [
+            "my_binary.runfiles/_main/my_binary",  # Remove duplicate binary
+        ],
+    ),
+)
+```
 """
 
 load("@bazel_lib//lib:expand_template.bzl", "expand_template")

--- a/tar/tests/BUILD
+++ b/tar/tests/BUILD
@@ -865,3 +865,105 @@ assert_tar_listing(
         "-rwxr-xr-x  0 1000    1000       21 Jan  1  2023 home/nonroot/dir/src_file",
     ],
 )
+
+#############
+# Example 23: Test excludes functionality - exclude specific files from tar
+mtree_spec(
+    name = "mtree23",
+    srcs = [
+        "src_file",
+        ":fixture1",
+    ],
+)
+
+mtree_mutate(
+    name = "exclude_generated",
+    excludes = [
+        "tar/tests/generated.txt",
+    ],
+    mtree = "mtree23",
+)
+
+tar(
+    name = "tar_excludes_single",
+    srcs = [
+        "src_file",
+        ":fixture1",
+    ],
+    out = "23.tar",
+    mtree = "exclude_generated",
+)
+
+assert_tar_listing(
+    name = "test23_excludes_single",
+    actual = "tar_excludes_single",
+    expected = [
+        "drwxr-xr-x  0 0      0           0 Jan  1  2023 tar/",
+        "drwxr-xr-x  0 0      0           0 Jan  1  2023 tar/tests/",
+        "-rwxr-xr-x  0 0      0          21 Jan  1  2023 tar/tests/src_file",
+    ],
+)
+
+#############
+# Example 24: Test multiple excludes
+mtree_mutate(
+    name = "exclude_multiple",
+    excludes = [
+        "tar/tests/generated.txt",
+        "tar/tests/src_file",
+    ],
+    mtree = "mtree23",
+)
+
+tar(
+    name = "tar_excludes_multiple",
+    srcs = [
+        "src_file",
+        ":fixture1",
+    ],
+    out = "24.tar",
+    mtree = "exclude_multiple",
+)
+
+assert_tar_listing(
+    name = "test24_excludes_multiple",
+    actual = "tar_excludes_multiple",
+    expected = [
+        "drwxr-xr-x  0 0      0           0 Jan  1  2023 tar/",
+        "drwxr-xr-x  0 0      0           0 Jan  1  2023 tar/tests/",
+    ],
+)
+
+#############
+# Example 25: Test excludes with strip_prefix and package_dir
+# Demonstrates transformation order: excludes → strip_prefix → package_dir
+mtree_mutate(
+    name = "exclude_with_strip_prefix_and_package_dir",
+    excludes = [
+        "tar/tests/generated.txt",
+    ],
+    mtree = "mtree23",
+    package_dir = "usr/local/bin",
+    strip_prefix = package_name(),
+)
+
+tar(
+    name = "tar_excludes_with_transformations",
+    srcs = [
+        "src_file",
+        ":fixture1",
+    ],
+    out = "25.tar",
+    mtree = "exclude_with_strip_prefix_and_package_dir",
+)
+
+assert_tar_listing(
+    name = "test25_excludes_with_strip_prefix",
+    actual = "tar_excludes_with_transformations",
+    expected = [
+        "drwxr-xr-x  0 0      0           0 Jan  1  2000 usr/",
+        "drwxr-xr-x  0 0      0           0 Jan  1  2000 usr/local/",
+        "drwxr-xr-x  0 0      0           0 Jan  1  2000 usr/local/bin/",
+        "-rwxr-xr-x  0 0      0          21 Jan  1  2023 usr/local/bin/src_file",
+    ],
+)


### PR DESCRIPTION
# Add `excludes` attribute to `mutate` rule

Closes [#71](https://github.com/bazel-contrib/tar.bzl/issues/71) 
Rebased version of https://github.com/bazel-contrib/tar.bzl/pull/86

## Usage

```starlark
tar(
    name = "my_app_tar",
    srcs = [":my_binary"],
    include_runfiles = True,
    mutate = mutate(
        excludes = [
            "my_binary.runfiles/_main/my_binary",
        ],
    ),
)
```

## Implementation

- **Exact path matching** with O(1) lookup using AWK associative arrays
- **Transformation order**: exclusions applied before `strip_prefix` and `package_dir`
- **Backward compatible**: optional attribute

## Tests

- Single and multiple file exclusions
- Interaction with `strip_prefix` and `package_dir` transformations

## Out of Scope

Paths with special characters (spaces, tabs, etc.) require vis-encoding/decoding. This should be addressed holistically across all path-related parameters (`strip_prefix`, `package_dir`, `excludes`) in a future.

